### PR TITLE
Add support for page and group in Wootric

### DIFF
--- a/integrations/wootric/lib/index.js
+++ b/integrations/wootric/lib/index.js
@@ -28,9 +28,6 @@ var Wootric = (module.exports = integration('Wootric')
  */
 
 Wootric.prototype.initialize = function() {
-  // We use this to keep track of the last page that Wootric has tracked to
-  // ensure we don't accidentally send a duplicate page call
-  this.lastPageTracked = null;
   window.wootricSettings = window.wootricSettings || {};
   window.wootricSettings.account_token = this.options.accountToken;
   window.wootricSettings.version = 'wootric-segment-js-2.3.0';
@@ -101,14 +98,21 @@ Wootric.prototype.track = function(track) {
  * @param {Page} page
  */
 
-Wootric.prototype.page = function() {
-  // Only track page if we haven't already tracked it
-  if (this.lastPageTracked === window.location) {
-    return;
-  }
+Wootric.prototype.page = function(page) {
+  window.wootricSettings.page_info = page.properties();
+  window.wootric('page');
+};
 
-  // Set this page as the last page tracked
-  this.lastPageTracked = window.location;
+/**
+ * Group.
+ *
+ * @api public
+ * @param {Group} group
+ */
+
+Wootric.prototype.group = function(group) {
+  window.wootricSettings.group_info = group.traits();
+  window.wootric('group');
 };
 
 /**

--- a/integrations/wootric/test/index.test.js
+++ b/integrations/wootric/test/index.test.js
@@ -69,10 +69,6 @@ describe('Wootric', function() {
         analytics.assert(window.wootricSettings.version);
       });
 
-      it('should have lastPageTracked set to null', function() {
-        analytics.assert(wootric.lastPageTracked === null);
-      });
-
       it('should call #load', function() {
         analytics.called(wootric.load);
       });
@@ -276,16 +272,39 @@ describe('Wootric', function() {
 
     describe('#page', function() {
       beforeEach(function() {
-        analytics.page({});
+        analytics.page('Pricing', {
+          title: 'Segment Pricing',
+          url: 'https://segment.com/pricing',
+          path: '/pricing',
+          referrer: 'https://segment.com/warehouses'
+        });
       });
 
       it('should track the current page', function() {
-        analytics.assert(window.wootricSettings);
-        analytics.assert(wootric.lastPageTracked);
+        analytics.equal(window.wootricSettings.page_info.name, 'Pricing');
+        analytics.equal(
+          window.wootricSettings.page_info.url,
+          'https://segment.com/pricing'
+        );
+      });
+    });
+
+    describe('#group', function() {
+      beforeEach(function() {
+        analytics.group('0e8c78ea9d97a7b8185e8632', {
+          name: 'Initech',
+          industry: 'Technology',
+          employees: 329,
+          plan: 'enterprise'
+        });
       });
 
-      it('should set lastPageTracked to window location', function() {
-        analytics.assert(wootric.lastPageTracked === window.location);
+      it('should send group traits to Wootric', function() {
+        analytics.equal(
+          window.wootricSettings.group_info.id,
+          '0e8c78ea9d97a7b8185e8632'
+        );
+        analytics.equal(window.wootricSettings.group_info.name, 'Initech');
       });
     });
 


### PR DESCRIPTION
**What does this PR do?**

Adds support for the page and group methods inside the Wootric integration.

**Are there breaking changes in this PR?**

No, all changes are backward compatible and have been tested.

**Any background context you want to provide?**

We are offering a new to [trigger surveys based on attributes](http://help.wootric.com/en/articles/3472284-how-do-i-setup-targeted-sampling-for-in-app-surveys). The inclusion of the attributes that `group` and `page` provide will give us more trigger points for our surveys. 

